### PR TITLE
Improved importing

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -62,7 +62,9 @@ pub struct ExportArgs {
 
 #[derive(Debug, Parser)]
 pub struct ImportArgs {
-    /// Path to the archive file.
+    /// Path to (or URL of) the archive file.
+    ///
+    /// Specify "launcher" to install the default launcher.
     #[arg()]
-    pub path: PathBuf,
+    pub path: String,
 }

--- a/src/build.rs
+++ b/src/build.rs
@@ -62,12 +62,12 @@ fn write_meta(config: &Config) -> anyhow::Result<()> {
 
 /// Write the latest installed app name into internal DB.
 fn write_installed(config: &Config) -> anyhow::Result<()> {
-    let meta = firefly_meta::ShortMeta {
+    let short_meta = firefly_meta::ShortMeta {
         app_id:    &config.app_id,
         author_id: &config.author_id,
     };
-    let mut buf = vec![0; meta.size()];
-    let encoded = meta.encode(&mut buf).context("serialize")?;
+    let mut buf = vec![0; short_meta.size()];
+    let encoded = short_meta.encode(&mut buf).context("serialize")?;
     let output_path = config.vfs_path.join("sys").join("new-app");
     fs::write(output_path, &encoded).context("write new-app file")?;
     if config.launcher {

--- a/src/import.rs
+++ b/src/import.rs
@@ -2,33 +2,53 @@ use crate::args::ImportArgs;
 use crate::vfs::{get_vfs_path, init_vfs};
 use anyhow::{bail, Context, Result};
 use firefly_meta::Meta;
-use std::fs::{create_dir_all, File};
+use std::fs::{self, create_dir_all, File};
 use std::io::Read;
-use std::path::PathBuf;
+use std::path::Path;
 use zip::ZipArchive;
 
 pub fn cmd_import(args: &ImportArgs) -> Result<()> {
     let file = File::open(&args.path).context("open archive file")?;
     let mut archive = ZipArchive::new(file).context("open archive")?;
-    let out_dir = get_out_path(&mut archive).context("get ROM path")?;
+
+    let meta_raw = read_meta_raw(&mut archive)?;
+    let meta = Meta::decode(&meta_raw).context("parse meta")?;
+    let vfs_path = get_vfs_path();
+    let rom_path = vfs_path.join("roms").join(meta.author_id).join(meta.app_id);
+
     init_vfs().context("init VFS")?;
-    create_dir_all(&out_dir).context("create ROM dir")?;
-    archive.extract(&out_dir).context("extract archive")?;
-    if let Some(out_dir) = out_dir.to_str() {
-        println!("✅ installed: {out_dir}");
+    create_dir_all(&rom_path).context("create ROM dir")?;
+    archive.extract(&rom_path).context("extract archive")?;
+    if let Some(rom_path) = rom_path.to_str() {
+        println!("✅ installed: {rom_path}");
     }
+    write_installed(&meta, &vfs_path)?;
     Ok(())
 }
 
-fn get_out_path(archive: &mut ZipArchive<File>) -> Result<PathBuf> {
+fn read_meta_raw(archive: &mut ZipArchive<File>) -> Result<Vec<u8>> {
     let mut meta_raw = Vec::new();
     let mut meta_file = archive.by_name("meta").context("open meta")?;
     meta_file.read_to_end(&mut meta_raw).context("read meta")?;
     if meta_raw.is_empty() {
         bail!("meta is empty");
     }
-    let meta = Meta::decode(&meta_raw).context("parse meta")?;
-    let vfs_path = get_vfs_path();
-    let rom_path = vfs_path.join("roms").join(meta.author_id).join(meta.app_id);
-    Ok(rom_path)
+    Ok(meta_raw)
+}
+
+/// Write the latest installed app name into internal DB.
+fn write_installed(meta: &Meta, vfs_path: &Path) -> anyhow::Result<()> {
+    let short_meta = firefly_meta::ShortMeta {
+        app_id:    meta.app_id,
+        author_id: meta.author_id,
+    };
+    let mut buf = vec![0; short_meta.size()];
+    let encoded = short_meta.encode(&mut buf).context("serialize")?;
+    let output_path = vfs_path.join("sys").join("new-app");
+    fs::write(output_path, &encoded).context("write new-app file")?;
+    if meta.launcher {
+        let output_path = vfs_path.join("sys").join("launcher");
+        fs::write(output_path, &encoded).context("write launcher file")?;
+    }
+    Ok(())
 }

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -75,7 +75,7 @@ pub fn optimize(bin_path: &Path) -> anyhow::Result<()> {
     }
 
     let output = Command::new("wasm-opt")
-        .args(["-Oz", "-o", bin_path, bin_path])
+        .args(["-Oz", "--all-features", "-o", bin_path, bin_path])
         .output()
         .context("run wasm-opt")?;
     if !output.status.success() {

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -71,6 +71,7 @@ pub fn optimize(bin_path: &Path) -> anyhow::Result<()> {
 
     let output = Command::new("wasm-opt").arg("--version").output();
     if output.is_err() {
+        println!("WARNING: wasm-opt not installed, the binary won't be optimized.");
         return Ok(());
     }
 


### PR DESCRIPTION
1. Support importing a launcher
2. `firefly_cli import launcher` will install the default launcher
3. Support importing a ROM from URL.
4. Support building Rust apps with the stable Rust compiler.