### PR TITLE
Initial support for C and C++ compilation

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -91,4 +91,7 @@ pub enum Lang {
     Rust,
     Zig,
     TS,
+    C,
+    Cpp,
+    Python,
 }


### PR DESCRIPTION
Compile C and C++ code using Zig. It's possible to compile it with clang (using wasi-sdk) or emscripten, both IMHO installation is more complicated in both cases. I might add support for these later. The disadvantage of Zig is that the supported libc seems smaller than in [wasi-sdk](https://github.com/WebAssembly/wasi-sdk) which uses [wasi-libc](https://github.com/WebAssembly/wasi-libc).