### PR TITLE
Rename the binary to ff

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,10 @@ categories = [
     "wasm",
 ]
 
+[[bin]]
+name = "ff"
+path = "src/main.rs"
+
 [dependencies]
 # Simpler error handling
 anyhow = "1.0.86"

--- a/README.md
+++ b/README.md
@@ -23,13 +23,17 @@ Swiss army knife CLI tool for working with [Firefly Zero](https://fireflyzero.co
 
 ## 🔧 Usage
 
+Some of the most commonly used commands:
+
 ```bash
 # build an app and install it into VFS
-firefly_cli build
+ff build
 
 # export an app installed in VFS
-firefly_cli export --author sys --app input-test
+ff export --author sys --app input-test
 
 # install an exported app into VFS
-firefly_cli import sys.input-test.zip
+ff import sys.input-test.zip
 ```
+
+Run `ff --help` to see the full list of available commands.


### PR DESCRIPTION
I'm not sure if that's a good way. Crates.io might reject the new name when we try to release. There is a feature but it's not stabilized yet:

https://github.com/rust-lang/cargo/issues/1706