### PR TITLE
Improve error message for too many colors

### DIFF
--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -76,7 +76,8 @@ pub fn cmd_build(vfs: PathBuf, args: &BuildArgs) -> anyhow::Result<()> {
     remove_old_files(&config.rom_path).context("remove old files")?;
     if let Some(files) = &config.files {
         for (name, file_config) in files {
-            convert_file(name, &config, file_config).context("convert file")?;
+            convert_file(name, &config, file_config)
+                .with_context(|| format!("convert \"{name}\""))?;
         }
     }
     write_badges(&config).context("write badges")?;

--- a/src/images.rs
+++ b/src/images.rs
@@ -48,7 +48,11 @@ pub fn convert_image(input_path: &Path, output_path: &Path) -> Result<()> {
         let palette = extend_palette(palette, 16);
         write_image::<4, 2>(out, &img, &palette).context("write 1BPP image")
     } else {
-        bail!("the image has too many colors")
+        let has_transparency = palette.iter().any(Option::is_none);
+        if has_transparency && colors == 17 {
+            bail!("cannot use all 16 colors with transparency, remove one color");
+        }
+        bail!("the image has too many colors");
     }
 }
 


### PR DESCRIPTION
Provide a better error message for when an image uses all 16 colors from the palette and transparency.

Closes #35