### PR TITLE
Go: use conservative GC

### DIFF
--- a/src/target.json
+++ b/src/target.json
@@ -8,7 +8,7 @@
   "linker": "wasm-ld",
   "rtlib": "compiler-rt",
   "scheduler": "none",
-  "gc": "leaking",
+  "gc": "conservative",
   "cflags": ["-mno-bulk-memory", "-mnontrapping-fptoint", "-msign-ext"],
   "ldflags": [
     "--allow-undefined",


### PR DESCRIPTION
Replace leaking GC with conservative. It's +2Kb but most apps will need proper de-allocations, so it's worth it.