### PR TITLE
Rebuild std when building rust apps

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@nightly
         with:
           targets: wasm32-unknown-unknown
       - uses: arduino/setup-task@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           toolchain: nightly
           targets: wasm32-unknown-unknown
+          components: rust-src
       - uses: arduino/setup-task@v1
         with:
           repo-token: ${{ github.token }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,8 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: nightly
           targets: wasm32-unknown-unknown
       - uses: arduino/setup-task@v1
         with:

--- a/src/langs.rs
+++ b/src/langs.rs
@@ -152,7 +152,14 @@ fn build_rust_inner(config: &Config, example: bool) -> anyhow::Result<()> {
         bail!("cannot convert project directory name to UTF-8")
     };
     let in_path = path_to_utf8(&config.root_path)?;
-    let mut cmd_args = vec!["build", "--target", "wasm32-unknown-unknown", "--release"];
+    let mut cmd_args = vec![
+        "+nightly",
+        "build",
+        "-Zbuild-std=std",
+        "--target",
+        "wasm32-unknown-unknown",
+        "--release",
+    ];
     if example {
         cmd_args.push("--example");
         cmd_args.push(example_name);


### PR DESCRIPTION
Some parts of stdlib pre-compiled with non-core wasm features enabled, which is weird. So, we recompile stdlib. Which requires rust nightly.