### PR TITLE
Optimize for speed

### DIFF
--- a/assets/build.zig
+++ b/assets/build.zig
@@ -6,7 +6,7 @@ pub fn build(b: *std.Build) void {
         .os_tag = .freestanding,
     };
     const target = b.resolveTargetQuery(target_query);
-    const optimize: std.builtin.OptimizeMode = .ReleaseSmall;
+    const optimize: std.builtin.OptimizeMode = .ReleaseFast;
     const exe = b.addExecutable(.{
         .name = "main",
         .root_module = b.createModule(.{

--- a/src/langs.rs
+++ b/src/langs.rs
@@ -313,7 +313,7 @@ fn build_cpp_inner(config: &Config, bin_name: &str, fname: &str) -> anyhow::Resu
         path_to_utf8(&out_path)?,
         "-mexec-model=reactor",
         "-Wl,--stack-first,--no-entry,--strip-all,--gc-sections,--lto-O3",
-        "-Oz",
+        "-Os",
         path_to_utf8(in_path)?,
     ];
     if let Some(additional_args) = &config.compile_args {

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -77,7 +77,8 @@ pub fn optimize(bin_path: &Path, strip: bool) -> anyhow::Result<()> {
 
     // https://github.com/wasmi-labs/wasmi/?tab=readme-ov-file#webassembly-features
     let mut args = vec![
-        "-Oz",
+        "-Os",
+        "--dae-optimizing",
         "--disable-exception-handling",
         "--disable-gc",
         "--disable-typed-function-references",
@@ -92,6 +93,7 @@ pub fn optimize(bin_path: &Path, strip: bool) -> anyhow::Result<()> {
         "--enable-sign-ext",
         "--enable-simd",
         "--enable-tail-call",
+        "--inlining-optimizing",
     ];
     if strip {
         args.push("--strip-debug");


### PR DESCRIPTION
Optimize all builds for speed rather than size. It adds not much to the AST size but in many cases really improves performance when it's needed the most. I already enabled it for the default Rust template as well.

Also closes #83
